### PR TITLE
[IOPAE-1489] add help button in header

### DIFF
--- a/.changeset/tender-worms-shop.md
+++ b/.changeset/tender-worms-shop.md
@@ -1,0 +1,6 @@
+---
+"io-ipatente-vehicles": minor
+"@io-ipatente/ui": minor
+---
+
+removed button naked from TopBar and add assistence in AppLayout

--- a/apps/vehicles/src/components/layouts/AppLayout.tsx
+++ b/apps/vehicles/src/components/layouts/AppLayout.tsx
@@ -4,6 +4,7 @@ import {
   TopBar,
 } from "@io-ipatente/ui";
 import Box from "@mui/material/Box";
+import { usePathname } from "next/navigation";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { ReactNode } from "react";
@@ -23,6 +24,7 @@ const AppLayout = ({
 }: AppLayoutProps) => {
   const { t } = useTranslation();
   const router = useRouter();
+  const path = usePathname();
 
   return (
     <Box display="flex" flexDirection="column" minHeight="100vh">
@@ -30,7 +32,9 @@ const AppLayout = ({
         assistance={{
           label: "",
           onClick: () => {
-            router.push("/"); // TODO -> add assistence routePath, done in IOPAE-1490
+            if (!path?.includes("assistance")) {
+              router.push("/assistance");
+            }
           },
         }}
         product={{

--- a/apps/vehicles/src/components/layouts/AppLayout.tsx
+++ b/apps/vehicles/src/components/layouts/AppLayout.tsx
@@ -28,7 +28,6 @@ const AppLayout = ({
     <Box display="flex" flexDirection="column" minHeight="100vh">
       <TopBar
         assistance={{
-          label: "",
           onClick: () => {
             router.push("/assistance");
           },

--- a/apps/vehicles/src/components/layouts/AppLayout.tsx
+++ b/apps/vehicles/src/components/layouts/AppLayout.tsx
@@ -4,7 +4,6 @@ import {
   TopBar,
 } from "@io-ipatente/ui";
 import Box from "@mui/material/Box";
-import { usePathname } from "next/navigation";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { ReactNode } from "react";
@@ -24,7 +23,6 @@ const AppLayout = ({
 }: AppLayoutProps) => {
   const { t } = useTranslation();
   const router = useRouter();
-  const path = usePathname();
 
   return (
     <Box display="flex" flexDirection="column" minHeight="100vh">
@@ -32,9 +30,7 @@ const AppLayout = ({
         assistance={{
           label: "",
           onClick: () => {
-            if (!path?.includes("assistance")) {
-              router.push("/assistance");
-            }
+            router.push("/assistance");
           },
         }}
         product={{

--- a/apps/vehicles/src/components/layouts/AppLayout.tsx
+++ b/apps/vehicles/src/components/layouts/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { PageHeader, TopBar } from "@io-ipatente/ui";
 import Box from "@mui/material/Box";
 import { ParseKeys } from "i18next";
+import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { ReactNode } from "react";
 
@@ -12,10 +13,17 @@ interface AppLayoutProps {
 
 const AppLayout = ({ children, description, title }: AppLayoutProps) => {
   const { t } = useTranslation();
+  const router = useRouter();
 
   return (
     <Box display="flex" flexDirection="column" minHeight="100vh">
       <TopBar
+        assistance={{
+          label: "",
+          onClick: () => {
+            router.push("/assistance");
+          },
+        }}
         product={{
           logo: "ipatente",
           name: t("topBar.product.name"),

--- a/apps/vehicles/src/components/layouts/AppLayout.tsx
+++ b/apps/vehicles/src/components/layouts/AppLayout.tsx
@@ -30,7 +30,7 @@ const AppLayout = ({
         assistance={{
           label: "",
           onClick: () => {
-            router.push("/assistance");
+            router.push("/"); // TODO -> add assistence routePath, done in IOPAE-1490
           },
         }}
         product={{

--- a/apps/vehicles/src/pages/assistance/index.tsx
+++ b/apps/vehicles/src/pages/assistance/index.tsx
@@ -1,0 +1,21 @@
+import AppLayout from "@/components/layouts/AppLayout";
+import { GetServerSideProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+
+import { GetLayoutProps } from "../_app";
+
+export default function Assitance() {
+  return null;
+}
+
+Assitance.getLayout = ({ page }: GetLayoutProps) => (
+  <AppLayout description={""} title={""}>
+    {page}
+  </AppLayout>
+);
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(locale as string, ["common"])),
+  },
+});

--- a/packages/ui/lib/components/top-bar/TopBar.tsx
+++ b/packages/ui/lib/components/top-bar/TopBar.tsx
@@ -43,7 +43,9 @@ export const TopBar = ({ assistance, product }: TopBarProps) => (
 
       {assistance && (
         <Stack alignItems="center" direction="row" spacing={2}>
-          {/* <ButtonNaked
+          {/* 
+           TODO -> IOPAE-1489 -> fix ButtonNaked problem with material UI
+          <ButtonNaked
             component="button"
             onClick={assistance.onClick}
             size="small"

--- a/packages/ui/lib/components/top-bar/TopBar.tsx
+++ b/packages/ui/lib/components/top-bar/TopBar.tsx
@@ -4,7 +4,6 @@ import { AppBar, IconButton, Link, Stack, Toolbar } from "@mui/material";
 import { Logo, LogoType } from "../logo";
 
 interface AssistanceProps {
-  label: string;
   onClick: () => void;
 }
 
@@ -43,7 +42,7 @@ export const TopBar = ({ assistance, product }: TopBarProps) => (
       {assistance && (
         <Stack alignItems="center" direction="row" spacing={2}>
           <IconButton
-            aria-label={assistance.label}
+            aria-label={"assistance-icon"}
             onClick={assistance.onClick}
             size="small"
           >

--- a/packages/ui/lib/components/top-bar/TopBar.tsx
+++ b/packages/ui/lib/components/top-bar/TopBar.tsx
@@ -1,6 +1,5 @@
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 import { AppBar, IconButton, Link, Stack, Toolbar } from "@mui/material";
-// import { ButtonNaked } from "@pagopa/mui-italia";
 
 import { Logo, LogoType } from "../logo";
 
@@ -43,23 +42,10 @@ export const TopBar = ({ assistance, product }: TopBarProps) => (
 
       {assistance && (
         <Stack alignItems="center" direction="row" spacing={2}>
-          {/* 
-           TODO -> IOPAE-1489 -> fix ButtonNaked problem with material UI
-          <ButtonNaked
-            component="button"
-            onClick={assistance.onClick}
-            size="small"
-            startIcon={<HelpOutlineRoundedIcon />}
-            sx={{ display: ["none", "flex"] }}
-            weight="default"
-          >
-            {assistance.label}
-          </ButtonNaked> */}
           <IconButton
             aria-label={assistance.label}
             onClick={assistance.onClick}
             size="small"
-            sx={{ display: ["flex", "none"] }}
           >
             <HelpOutlineRoundedIcon fontSize="inherit" />
           </IconButton>

--- a/packages/ui/lib/components/top-bar/TopBar.tsx
+++ b/packages/ui/lib/components/top-bar/TopBar.tsx
@@ -42,7 +42,7 @@ export const TopBar = ({ assistance, product }: TopBarProps) => (
       {assistance && (
         <Stack alignItems="center" direction="row" spacing={2}>
           <IconButton
-            aria-label={"assistance-icon"}
+            aria-label={"assistance"}
             onClick={assistance.onClick}
             size="small"
           >

--- a/packages/ui/lib/components/top-bar/TopBar.tsx
+++ b/packages/ui/lib/components/top-bar/TopBar.tsx
@@ -1,6 +1,6 @@
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 import { AppBar, IconButton, Link, Stack, Toolbar } from "@mui/material";
-import { ButtonNaked } from "@pagopa/mui-italia";
+// import { ButtonNaked } from "@pagopa/mui-italia";
 
 import { Logo, LogoType } from "../logo";
 
@@ -43,7 +43,7 @@ export const TopBar = ({ assistance, product }: TopBarProps) => (
 
       {assistance && (
         <Stack alignItems="center" direction="row" spacing={2}>
-          <ButtonNaked
+          {/* <ButtonNaked
             component="button"
             onClick={assistance.onClick}
             size="small"
@@ -52,7 +52,7 @@ export const TopBar = ({ assistance, product }: TopBarProps) => (
             weight="default"
           >
             {assistance.label}
-          </ButtonNaked>
+          </ButtonNaked> */}
           <IconButton
             aria-label={assistance.label}
             onClick={assistance.onClick}

--- a/packages/ui/lib/components/top-bar/__tests__/TopBar.test.tsx
+++ b/packages/ui/lib/components/top-bar/__tests__/TopBar.test.tsx
@@ -43,7 +43,7 @@ describe("Test TopBar Components", () => {
       />,
     );
 
-    const button = await comp.findByText("Assistenza");
+    const button = comp.getByLabelText("Assistenza");
     fireEvent.click(button);
     expect(mockHandleClick).toHaveBeenCalledTimes(1);
   });

--- a/packages/ui/lib/components/top-bar/__tests__/TopBar.test.tsx
+++ b/packages/ui/lib/components/top-bar/__tests__/TopBar.test.tsx
@@ -41,7 +41,7 @@ describe("Test TopBar Components", () => {
       />,
     );
 
-    const button = comp.getByLabelText("assistance-icon");
+    const button = comp.getByLabelText("assistance");
     fireEvent.click(button);
     expect(mockHandleClick).toHaveBeenCalledTimes(1);
   });

--- a/packages/ui/lib/components/top-bar/__tests__/TopBar.test.tsx
+++ b/packages/ui/lib/components/top-bar/__tests__/TopBar.test.tsx
@@ -24,7 +24,6 @@ describe("Test TopBar Components", () => {
       <TopBar
         {...defaultProps}
         assistance={{
-          label: "Assistenza",
           onClick: mockHandleClick,
         }}
       />,
@@ -37,13 +36,12 @@ describe("Test TopBar Components", () => {
       <TopBar
         {...defaultProps}
         assistance={{
-          label: "Assistenza",
           onClick: mockHandleClick,
         }}
       />,
     );
 
-    const button = comp.getByLabelText("Assistenza");
+    const button = comp.getByLabelText("assistance-icon");
     fireEvent.click(button);
     expect(mockHandleClick).toHaveBeenCalledTimes(1);
   });

--- a/packages/ui/lib/components/top-bar/__tests__/__snapshots__/TopBar.test.tsx.snap
+++ b/packages/ui/lib/components/top-bar/__tests__/__snapshots__/TopBar.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Test TopBar Components > Should match the snapshot when assistance is t
           >
             <button
               aria-label="Assistenza"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-mnnzy1-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="button"
             >
@@ -118,7 +118,7 @@ exports[`Test TopBar Components > Should match the snapshot when assistance is t
         >
           <button
             aria-label="Assistenza"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-mnnzy1-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >

--- a/packages/ui/lib/components/top-bar/__tests__/__snapshots__/TopBar.test.tsx.snap
+++ b/packages/ui/lib/components/top-bar/__tests__/__snapshots__/TopBar.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Test TopBar Components > Should match the snapshot when assistance is t
             class="MuiStack-root css-1sos3zc-MuiStack-root"
           >
             <button
-              aria-label="assistance-icon"
+              aria-label="assistance"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="button"
@@ -117,7 +117,7 @@ exports[`Test TopBar Components > Should match the snapshot when assistance is t
           class="MuiStack-root css-1sos3zc-MuiStack-root"
         >
           <button
-            aria-label="assistance-icon"
+            aria-label="assistance"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"

--- a/packages/ui/lib/components/top-bar/__tests__/__snapshots__/TopBar.test.tsx.snap
+++ b/packages/ui/lib/components/top-bar/__tests__/__snapshots__/TopBar.test.tsx.snap
@@ -48,28 +48,6 @@ exports[`Test TopBar Components > Should match the snapshot when assistance is t
             class="MuiStack-root css-1sos3zc-MuiStack-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-naked MuiButton-nakedText MuiButton-sizeSmall MuiButton-nakedSizeSmall MuiButton-colorText MuiButton-root MuiButton-naked MuiButton-nakedText MuiButton-sizeSmall MuiButton-nakedSizeSmall MuiButton-colorText css-1bmlfez-MuiButtonBase-root-MuiButton-root"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                  data-testid="HelpOutlineRoundedIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8m-1-4h2v2h-2zm1.61-9.96c-2.06-.3-3.88.97-4.43 2.79-.18.58.26 1.17.87 1.17h.2c.41 0 .74-.29.88-.67.32-.89 1.27-1.5 2.3-1.28.95.2 1.65 1.13 1.57 2.1-.1 1.34-1.62 1.63-2.45 2.88 0 .01-.01.01-.01.02-.01.02-.02.03-.03.05-.09.15-.18.32-.25.5-.01.03-.03.05-.04.08-.01.02-.01.04-.02.07-.12.34-.2.75-.2 1.25h2c0-.42.11-.77.28-1.07.02-.03.03-.06.05-.09.08-.14.18-.27.28-.39.01-.01.02-.03.03-.04.1-.12.21-.23.33-.34.96-.91 2.26-1.65 1.99-3.56-.24-1.74-1.61-3.21-3.35-3.47"
-                  />
-                </svg>
-              </span>
-              Assistenza
-            </button>
-            <button
               aria-label="Assistenza"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-mnnzy1-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
@@ -138,28 +116,6 @@ exports[`Test TopBar Components > Should match the snapshot when assistance is t
         <div
           class="MuiStack-root css-1sos3zc-MuiStack-root"
         >
-          <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-naked MuiButton-nakedText MuiButton-sizeSmall MuiButton-nakedSizeSmall MuiButton-colorText MuiButton-root MuiButton-naked MuiButton-nakedText MuiButton-sizeSmall MuiButton-nakedSizeSmall MuiButton-colorText css-1bmlfez-MuiButtonBase-root-MuiButton-root"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                data-testid="HelpOutlineRoundedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8m-1-4h2v2h-2zm1.61-9.96c-2.06-.3-3.88.97-4.43 2.79-.18.58.26 1.17.87 1.17h.2c.41 0 .74-.29.88-.67.32-.89 1.27-1.5 2.3-1.28.95.2 1.65 1.13 1.57 2.1-.1 1.34-1.62 1.63-2.45 2.88 0 .01-.01.01-.01.02-.01.02-.02.03-.03.05-.09.15-.18.32-.25.5-.01.03-.03.05-.04.08-.01.02-.01.04-.02.07-.12.34-.2.75-.2 1.25h2c0-.42.11-.77.28-1.07.02-.03.03-.06.05-.09.08-.14.18-.27.28-.39.01-.01.02-.03.03-.04.1-.12.21-.23.33-.34.96-.91 2.26-1.65 1.99-3.56-.24-1.74-1.61-3.21-3.35-3.47"
-                />
-              </svg>
-            </span>
-            Assistenza
-          </button>
           <button
             aria-label="Assistenza"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-mnnzy1-MuiButtonBase-root-MuiIconButton-root"

--- a/packages/ui/lib/components/top-bar/__tests__/__snapshots__/TopBar.test.tsx.snap
+++ b/packages/ui/lib/components/top-bar/__tests__/__snapshots__/TopBar.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Test TopBar Components > Should match the snapshot when assistance is t
             class="MuiStack-root css-1sos3zc-MuiStack-root"
           >
             <button
-              aria-label="Assistenza"
+              aria-label="assistance-icon"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="button"
@@ -117,7 +117,7 @@ exports[`Test TopBar Components > Should match the snapshot when assistance is t
           class="MuiStack-root css-1sos3zc-MuiStack-root"
         >
           <button
-            aria-label="Assistenza"
+            aria-label="assistance-icon"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"

--- a/packages/ui/stories/TopBar.stories.ts
+++ b/packages/ui/stories/TopBar.stories.ts
@@ -3,9 +3,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { TopBar } from "../lib/components/top-bar";
 
 const meta = {
-  title: "Components/TopBar",
   component: TopBar,
   tags: ["autodocs"],
+  title: "Components/TopBar",
 } satisfies Meta<typeof TopBar>;
 
 export default meta;
@@ -15,22 +15,21 @@ export const Default: Story = {
   args: {
     product: {
       logo: "ipatente",
-      url: "",
       name: "Il portale dell'automobilista",
+      url: "",
     },
   },
 };
 
 export const WithAssistance: Story = {
   args: {
+    assistance: {
+      onClick: () => null,
+    },
     product: {
       logo: "ipatente",
-      url: "",
       name: "Il portale dell'automobilista",
-    },
-    assistance: {
-      label: "Assistenza",
-      onClick: () => {},
+      url: "",
     },
   },
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

The assistance button has been added to the top bar.
The top bar component has been modified due to issues with the ButtonNaked component.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
There is a need to access a new support page starting from the page header.

#### How Has This Been Tested?
From any page, in the top right corner, in mobile responsive mode, the assistance icon can be seen in the header

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->
![hepl](https://github.com/user-attachments/assets/a0e00e77-0adf-4f36-95e0-08a06e2dee1a)



#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
