### PR TITLE
[IOPAE-1612] Move auth callback route to @io-ipatente/core

### DIFF
--- a/.changeset/proud-parrots-divide.md
+++ b/.changeset/proud-parrots-divide.md
@@ -1,0 +1,9 @@
+---
+"io-ipatente-practices": patch
+"io-ipatente-licences": patch
+"io-ipatente-payments": patch
+"io-ipatente-vehicles": patch
+"@io-ipatente/core": patch
+---
+
+Move auth callback route to @io-ipatente/core

--- a/apps/licences/src/app/api/auth/callback/fims/cookies/route.ts
+++ b/apps/licences/src/app/api/auth/callback/fims/cookies/route.ts
@@ -1,19 +1,3 @@
-import { NextRequest, NextResponse } from "next/server";
+import { AuthCallback } from "@io-ipatente/core";
 
-export const GET = async (req: NextRequest) => {
-  // TODO: Find a better way to handle cookies
-  const cookieState = req.nextUrl.searchParams.get("authjs.state") ?? "";
-  const cookieCallbackUrl =
-    req.nextUrl.searchParams.get("authjs.callback-url") ?? "";
-
-  req.nextUrl.pathname = "/api/auth/callback/fims";
-  req.nextUrl.searchParams.delete("authjs.state");
-  req.nextUrl.searchParams.delete("authjs.callback-url");
-
-  const response = NextResponse.redirect(req.nextUrl);
-
-  response.cookies.set("authjs.state", cookieState);
-  response.cookies.set("authjs.callback-url", cookieCallbackUrl);
-
-  return response;
-};
+export const { GET } = AuthCallback.handlers;

--- a/apps/payments/src/app/api/auth/callback/fims/cookies/route.ts
+++ b/apps/payments/src/app/api/auth/callback/fims/cookies/route.ts
@@ -1,19 +1,3 @@
-import { NextRequest, NextResponse } from "next/server";
+import { AuthCallback } from "@io-ipatente/core";
 
-export const GET = async (req: NextRequest) => {
-  // TODO: Find a better way to handle cookies
-  const cookieState = req.nextUrl.searchParams.get("authjs.state") ?? "";
-  const cookieCallbackUrl =
-    req.nextUrl.searchParams.get("authjs.callback-url") ?? "";
-
-  req.nextUrl.pathname = "/api/auth/callback/fims";
-  req.nextUrl.searchParams.delete("authjs.state");
-  req.nextUrl.searchParams.delete("authjs.callback-url");
-
-  const response = NextResponse.redirect(req.nextUrl);
-
-  response.cookies.set("authjs.state", cookieState);
-  response.cookies.set("authjs.callback-url", cookieCallbackUrl);
-
-  return response;
-};
+export const { GET } = AuthCallback.handlers;

--- a/apps/practices/src/app/api/auth/callback/fims/cookies/route.ts
+++ b/apps/practices/src/app/api/auth/callback/fims/cookies/route.ts
@@ -1,19 +1,3 @@
-import { NextRequest, NextResponse } from "next/server";
+import { AuthCallback } from "@io-ipatente/core";
 
-export const GET = async (req: NextRequest) => {
-  // TODO: Find a better way to handle cookies
-  const cookieState = req.nextUrl.searchParams.get("authjs.state") ?? "";
-  const cookieCallbackUrl =
-    req.nextUrl.searchParams.get("authjs.callback-url") ?? "";
-
-  req.nextUrl.pathname = "/api/auth/callback/fims";
-  req.nextUrl.searchParams.delete("authjs.state");
-  req.nextUrl.searchParams.delete("authjs.callback-url");
-
-  const response = NextResponse.redirect(req.nextUrl);
-
-  response.cookies.set("authjs.state", cookieState);
-  response.cookies.set("authjs.callback-url", cookieCallbackUrl);
-
-  return response;
-};
+export const { GET } = AuthCallback.handlers;

--- a/apps/vehicles/src/app/api/auth/callback/fims/cookies/route.ts
+++ b/apps/vehicles/src/app/api/auth/callback/fims/cookies/route.ts
@@ -1,19 +1,3 @@
-import { NextRequest, NextResponse } from "next/server";
+import { AuthCallback } from "@io-ipatente/core";
 
-export const GET = async (req: NextRequest) => {
-  // TODO: Find a better way to handle cookies
-  const cookieState = req.nextUrl.searchParams.get("authjs.state") ?? "";
-  const cookieCallbackUrl =
-    req.nextUrl.searchParams.get("authjs.callback-url") ?? "";
-
-  req.nextUrl.pathname = "/api/auth/callback/fims";
-  req.nextUrl.searchParams.delete("authjs.state");
-  req.nextUrl.searchParams.delete("authjs.callback-url");
-
-  const response = NextResponse.redirect(req.nextUrl);
-
-  response.cookies.set("authjs.state", cookieState);
-  response.cookies.set("authjs.callback-url", cookieCallbackUrl);
-
-  return response;
-};
+export const { GET } = AuthCallback.handlers;

--- a/packages/core/lib/api/__tests__/auth-callback-handlers.test.ts
+++ b/packages/core/lib/api/__tests__/auth-callback-handlers.test.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import { AuthCallback } from "../auth-callback-handlers";
+
+describe("AuthCallback", () => {
+  it("should set cookies from query parameters in the request", async () => {
+    const mockNextRequest = new NextRequest("https://example.com");
+
+    mockNextRequest.nextUrl.searchParams.append("authjs.state", "12345");
+    mockNextRequest.nextUrl.searchParams.append(
+      "authjs.callback-url",
+      "https://callback.com",
+    );
+
+    const response = await AuthCallback.handlers.GET(mockNextRequest);
+
+    expect(response.cookies.get("authjs.state")).toBeDefined();
+    expect(response.cookies.get("authjs.callback-url")).toBeDefined();
+    expect(response.cookies.get("prefix.name")).toBeUndefined();
+  });
+});

--- a/packages/core/lib/api/auth-callback-handlers.ts
+++ b/packages/core/lib/api/auth-callback-handlers.ts
@@ -1,0 +1,46 @@
+import type { NextRequest } from "next/server";
+
+import { NextResponse } from "next/server";
+
+const PREFIX_COOKIE = "authjs.";
+
+const handleAuthCallback = async (req: NextRequest): Promise<NextResponse> => {
+  const cookies: Record<string, string> = {};
+
+  req.nextUrl.searchParams.forEach((value, key) => {
+    if (key.startsWith(PREFIX_COOKIE)) {
+      cookies[key] = value;
+    }
+  });
+
+  req.nextUrl.pathname = "/api/auth/callback/fims";
+
+  req.nextUrl.searchParams.forEach((_, key) => {
+    if (key.startsWith(PREFIX_COOKIE)) {
+      req.nextUrl.searchParams.delete(key);
+    }
+  });
+
+  const response = NextResponse.redirect(req.nextUrl);
+
+  Object.entries(cookies).forEach(([key, value]) => {
+    response.cookies.set(key, value);
+  });
+
+  return response;
+};
+
+type AppRouteHandlers = Record<
+  "GET",
+  (req: NextRequest) => Promise<NextResponse>
+>;
+
+interface AuthCallbackResult {
+  handlers: AppRouteHandlers;
+}
+
+export const AuthCallback: AuthCallbackResult = {
+  handlers: {
+    GET: async (req: NextRequest) => handleAuthCallback(req),
+  },
+};

--- a/packages/core/lib/api/index.ts
+++ b/packages/core/lib/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./auth-callback-handlers";

--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -1,3 +1,4 @@
+export * from "./api";
 export * from "./auth";
 export * from "./config";
 export * from "./interop";

--- a/packages/core/lib/wrappers/__tests__/with-jwt-auth-handler.test.ts
+++ b/packages/core/lib/wrappers/__tests__/with-jwt-auth-handler.test.ts
@@ -34,7 +34,6 @@ describe("withJWTAuthHandler", () => {
 
     await withJWTAuthHandler(mockHandler)(mockNextAuthRequest, mockContext);
 
-    // Verifica che handleUnauthorizedErrorResponse venga chiamato
     expect(handleUnauthorizedErrorResponse).toHaveBeenCalledWith(
       "No Authentication provided",
     );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR is only intended to move the auth callback route to @io-ipatente/core

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Need to have a shared auth callback route

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Local dev mode with msw mocks.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
