### PR TITLE
make availability alerts less strict

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-* @pagopa/io-platform-green-unit
+* @pagopa/io-platform-green-unit @pagopa/io-institutions-n-services
 
-/infra/ @pagopa/engineering-team-cloud-eng @pagopa/io-platform-green-unit
-/.github/ @pagopa/engineering-team-cloud-eng @pagopa/io-platform-green-unit
+/infra/ @pagopa/engineering-team-cloud-eng @pagopa/io-platform-green-unit @pagopa/io-institutions-n-services
+/.github/ @pagopa/engineering-team-cloud-eng @pagopa/io-platform-green-unit @pagopa/io-institutions-n-services

--- a/apps/licences/.opex/licences/env/prod/config.yaml
+++ b/apps/licences/.opex/licences/env/prod/config.yaml
@@ -13,11 +13,11 @@ overrides:
     - licences.ipatente.io.pagopa.it
   endpoints:
     /puntiPatente:
-      availability_threshold: 0.95 # Default: 99%
+      availability_threshold: 0.9 # Default: 99%
       availability_evaluation_frequency: 30 # Default: 10
       availability_evaluation_time_window: 50 # Default: 20
       availability_event_occurrences: 3 # Default: 1
-      response_time_threshold: 2 # Default: 1
+      response_time_threshold: 1 # Default: 1
       response_time_evaluation_frequency: 35 # Default: 10
       response_time_evaluation_time_window: 55 # Default: 20
-      response_time_event_occurrences: 5 # Default: 1
+      response_time_event_occurrences: 3 # Default: 1

--- a/apps/vehicles/.opex/vehicles/env/prod/config.yaml
+++ b/apps/vehicles/.opex/vehicles/env/prod/config.yaml
@@ -12,11 +12,11 @@ overrides:
   hosts:
     - vehicles.ipatente.io.pagopa.it
   /infoVeicoli:
-    availability_threshold: 0.95 # Default: 99%
+    availability_threshold: 0.9 # Default: 99%
     availability_evaluation_frequency: 30 # Default: 10
     availability_evaluation_time_window: 50 # Default: 20
     availability_event_occurrences: 3 # Default: 1
-    response_time_threshold: 2 # Default: 1
+    response_time_threshold: 1 # Default: 1
     response_time_evaluation_frequency: 35 # Default: 10
     response_time_evaluation_time_window: 55 # Default: 20
-    response_time_event_occurrences: 5 # Default: 1
+    response_time_event_occurrences: 3 # Default: 1


### PR DESCRIPTION
Make availability alerts (from OPEX dashboard) less strict in order to keep monitoring channel less chaotic